### PR TITLE
Add support for Tesla V100

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           time: "00:10:00"
           commands: |
             BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
+            source /etc/profile
             module load spack/d4468dcc
             module load cmake cuda
             cmake -S . -B ${BUILD_DIR} -DCMAKE_CUDA_ARCHITECTURES=70

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,24 @@ name: test
 on:
   push:
 jobs:
+  test-v100:
+    name: NVIDIA V100
+    runs-on: [slurm]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astron-rd/slurm-action@v1
+        with:
+          partition: cbtq
+          gres: gpu:V100
+          time: "00:10:00"
+          commands: |
+            BUILD_DIR=$(mktemp -d -t build-XXXXXXXX)
+            module load spack/d4468dcc
+            module load cmake cuda
+            cmake -S . -B ${BUILD_DIR} -DCMAKE_CUDA_ARCHITECTURES=70
+            make -C ${BUILD_DIR} -j
+            ${BUILD_DIR}/benchmarks/fp32
+            ${BUILD_DIR}/benchmarks/mma
   test-a4000:
     name: NVIDIA A4000
     runs-on: [slurm]

--- a/benchmarks/mma.cpp
+++ b/benchmarks/mma.cpp
@@ -75,18 +75,22 @@ int main(int argc, const char *argv[]) {
                     "mma_xf32_16_16_8", gops * (16 * 16 * 8 * 2), gbytes);
     }
 #else
-    benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_xor), grid, block,
-                  "bmma_b1_16_8_256_xor", gops * (16 * 8 * 256 * 2), gbytes);
-    benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_and), grid, block,
-                  "bmma_b1_16_8_256_and", gops * (16 * 8 * 256 * 2), gbytes);
-    benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_xor), grid, block,
-                  "bmma_b1_8_8_128_xor", gops * (8 * 8 * 128 * 2), gbytes);
-    benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_and), grid, block,
-                  "bmma_b1_8_8_128_and", gops * (8 * 8 * 128 * 2), gbytes);
-    benchmark.run(reinterpret_cast<void *>(&mma_s4_8_8_32), grid, block,
-                  "mma_s4_8_8_32", gops * (8 * 8 * 32 * 2), gbytes);
-    benchmark.run(reinterpret_cast<void *>(&mma_s8_16_16_16), grid, block,
-                  "mma_s8_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+    if (!benchmark.isVolta()) {
+      benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_xor), grid,
+                    block, "bmma_b1_16_8_256_xor", gops * (16 * 8 * 256 * 2),
+                    gbytes);
+      benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_and), grid,
+                    block, "bmma_b1_16_8_256_and", gops * (16 * 8 * 256 * 2),
+                    gbytes);
+      benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_xor), grid, block,
+                    "bmma_b1_8_8_128_xor", gops * (8 * 8 * 128 * 2), gbytes);
+      benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_and), grid, block,
+                    "bmma_b1_8_8_128_and", gops * (8 * 8 * 128 * 2), gbytes);
+      benchmark.run(reinterpret_cast<void *>(&mma_s4_8_8_32), grid, block,
+                    "mma_s4_8_8_32", gops * (8 * 8 * 32 * 2), gbytes);
+      benchmark.run(reinterpret_cast<void *>(&mma_s8_16_16_16), grid, block,
+                    "mma_s8_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+    }
     if (benchmark.isAda() || benchmark.isHopper() || benchmark.isBlackwell()) {
       benchmark.run(reinterpret_cast<void *>(&mma_e4m3_16_8_32), grid, block,
                     "mma_e4m3_16_8_32", gops * (16 * 8 * 32 * 2), gbytes);
@@ -96,9 +100,10 @@ int main(int argc, const char *argv[]) {
 #endif
     benchmark.run(reinterpret_cast<void *>(&mma_f16_16_16_16), grid, block,
                   "mma_f16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
-    benchmark.run(reinterpret_cast<void *>(&mma_bf16_16_16_16), grid, block,
-                  "mma_bf16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
-
+    if (!benchmark.isVolta()) {
+      benchmark.run(reinterpret_cast<void *>(&mma_bf16_16_16_16), grid, block,
+                    "mma_bf16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+    }
 #if defined(__HIP_PLATFORM_AMD__)
     // F32 is only available on CDNA
     if (benchmark.isCDNA()) {
@@ -111,8 +116,10 @@ int main(int argc, const char *argv[]) {
                     "mma_f64_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
     }
 #else
-    benchmark.run(reinterpret_cast<void *>(&mma_tf32_16_16_8), grid, block,
-                  "mma_tf32_16_16_8", gops * (16 * 16 * 8 * 2), gbytes);
+    if (!benchmark.isVolta()) {
+      benchmark.run(reinterpret_cast<void *>(&mma_tf32_16_16_8), grid, block,
+                    "mma_tf32_16_16_8", gops * (16 * 16 * 8 * 2), gbytes);
+    }
 #endif
   }
 

--- a/benchmarks/mma.cpp
+++ b/benchmarks/mma.cpp
@@ -100,10 +100,14 @@ int main(int argc, const char *argv[]) {
 #endif
     benchmark.run(reinterpret_cast<void *>(&mma_f16_16_16_16), grid, block,
                   "mma_f16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+#if defined(!__HIP_PLATFORM_AMD__)
     if (!benchmark.isVolta()) {
+#endif
       benchmark.run(reinterpret_cast<void *>(&mma_bf16_16_16_16), grid, block,
                     "mma_bf16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
+#if defined(!__HIP_PLATFORM_AMD__)
     }
+#endif
 #if defined(__HIP_PLATFORM_AMD__)
     // F32 is only available on CDNA
     if (benchmark.isCDNA()) {

--- a/benchmarks/mma.cpp
+++ b/benchmarks/mma.cpp
@@ -100,12 +100,12 @@ int main(int argc, const char *argv[]) {
 #endif
     benchmark.run(reinterpret_cast<void *>(&mma_f16_16_16_16), grid, block,
                   "mma_f16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
-#if defined(!__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__)
     if (!benchmark.isVolta()) {
 #endif
       benchmark.run(reinterpret_cast<void *>(&mma_bf16_16_16_16), grid, block,
                     "mma_bf16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
-#if defined(!__HIP_PLATFORM_AMD__)
+#if !defined(__HIP_PLATFORM_AMD__)
     }
 #endif
 #if defined(__HIP_PLATFORM_AMD__)

--- a/common/Benchmark.cpp
+++ b/common/Benchmark.cpp
@@ -179,6 +179,11 @@ bool Benchmark::isRDNA3() {
           (arch.find("gfx1102") != std::string::npos));
 }
 #else
+bool Benchmark::isVolta() {
+  const std::string arch(device_->getArch());
+  return (arch.find("sm_70") != std::string::npos);
+}
+
 bool Benchmark::isAda() {
   const std::string arch(device_->getArch());
   return (arch.find("sm_89") != std::string::npos);

--- a/common/Benchmark.h
+++ b/common/Benchmark.h
@@ -28,6 +28,7 @@ public:
   bool isRDNA2();
   bool isRDNA3();
 #else
+  bool isVolta();
   bool isAda();
   bool isHopper();
   bool isBlackwell();

--- a/kernels/mma_m16n8k32_f32f8f8f32.cuh
+++ b/kernels/mma_m16n8k32_f32f8f8f32.cuh
@@ -1,3 +1,10 @@
+inline __device__ unsigned laneid() {
+  unsigned laneid;
+
+  asm("mov.u32 %0, %%laneid;" : "=r"(laneid));
+  return laneid;
+}
+
 template <>
 class fragment<matrix_a, 16, 8, 32, __nv_fp8_e4m3, row_major>
     : public __frag_base<int, 4> {};


### PR DESCRIPTION
The Tesla V100's tensor cores only support fp16 precision, all other precisions in the `mma` benchmark are disabled.