### PR TITLE
Add support for Turing

### DIFF
--- a/benchmarks/mma.cpp
+++ b/benchmarks/mma.cpp
@@ -75,7 +75,7 @@ int main(int argc, const char *argv[]) {
                     "mma_xf32_16_16_8", gops * (16 * 16 * 8 * 2), gbytes);
     }
 #else
-    if (!benchmark.isVolta()) {
+    if (!benchmark.isVolta() && !benchmark.isTuring()) {
       benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_xor), grid,
                     block, "bmma_b1_16_8_256_xor", gops * (16 * 8 * 256 * 2),
                     gbytes);
@@ -86,6 +86,8 @@ int main(int argc, const char *argv[]) {
                     "bmma_b1_8_8_128_xor", gops * (8 * 8 * 128 * 2), gbytes);
       benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_and), grid, block,
                     "bmma_b1_8_8_128_and", gops * (8 * 8 * 128 * 2), gbytes);
+    }
+    if (!benchmark.isVolta()) {
       benchmark.run(reinterpret_cast<void *>(&mma_s4_8_8_32), grid, block,
                     "mma_s4_8_8_32", gops * (8 * 8 * 32 * 2), gbytes);
       benchmark.run(reinterpret_cast<void *>(&mma_s8_16_16_16), grid, block,
@@ -101,7 +103,7 @@ int main(int argc, const char *argv[]) {
     benchmark.run(reinterpret_cast<void *>(&mma_f16_16_16_16), grid, block,
                   "mma_f16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
 #if !defined(__HIP_PLATFORM_AMD__)
-    if (!benchmark.isVolta()) {
+    if (!benchmark.isVolta() && !benchmark.isTuring()) {
 #endif
       benchmark.run(reinterpret_cast<void *>(&mma_bf16_16_16_16), grid, block,
                     "mma_bf16_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
@@ -120,7 +122,7 @@ int main(int argc, const char *argv[]) {
                     "mma_f64_16_16_16", gops * (16 * 16 * 16 * 2), gbytes);
     }
 #else
-    if (!benchmark.isVolta()) {
+    if (!benchmark.isVolta() && !benchmark.isTuring()) {
       benchmark.run(reinterpret_cast<void *>(&mma_tf32_16_16_8), grid, block,
                     "mma_tf32_16_16_8", gops * (16 * 16 * 8 * 2), gbytes);
     }

--- a/common/Benchmark.cpp
+++ b/common/Benchmark.cpp
@@ -184,6 +184,11 @@ bool Benchmark::isVolta() {
   return (arch.find("sm_70") != std::string::npos);
 }
 
+bool Benchmark::isTuring() {
+  const std::string arch(device_->getArch());
+  return (arch.find("sm_75") != std::string::npos);
+}
+
 bool Benchmark::isAda() {
   const std::string arch(device_->getArch());
   return (arch.find("sm_89") != std::string::npos);

--- a/common/Benchmark.h
+++ b/common/Benchmark.h
@@ -29,6 +29,7 @@ public:
   bool isRDNA3();
 #else
   bool isVolta();
+  bool isTuring();
   bool isAda();
   bool isHopper();
   bool isBlackwell();

--- a/kernels/mma.cu
+++ b/kernels/mma.cu
@@ -139,13 +139,13 @@ __device__ void mma_kernel(Tout *data) {
 
 #if defined(__CUDA_SUBBYTE_IMMA__)
 #define ENABLE_INT1
-#define ENABLE_INT4
 #include "mma_m16n8k256_s32b1b1s32.cuh"
-#include "mma_m8n8k32_s32s4s4s32.cuh"
 #endif
 
-#if __CUDA_ARCH >= 750
+#if __CUDA_ARCH__ >= 750
+#define ENABLE_INT4
 #define ENABLE_INT8
+#include "mma_m8n8k32_s32s4s4s32.cuh"
 #endif
 
 #if __CUDA_ARCH >= 800


### PR DESCRIPTION
Turing GPUs (e.g. NVIDIA Titan RTX) support Tensor Core operations in float16, int8 and int4 precision. All the others are disabled.