### PR TITLE
Fix mma benchmarks for Blackwell, improve Turing compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           gres: gpu:W7700
           time: "00:10:00"
           commands: |-
-            cmake -S . -B build -DBUILD_WITH_HIP=1 -DCMAKE_HIP_ARCHITECTURES=gfx1101
+            PATH=$PATH:/opt/rocm/bin cmake -S . -B build -DBUILD_WITH_HIP=1 -DCMAKE_HIP_ARCHITECTURES=gfx1101
             make -C build -j
             ./build/benchmarks/fp32
             ./build/benchmarks/mma

--- a/benchmarks/mma.cpp
+++ b/benchmarks/mma.cpp
@@ -75,17 +75,20 @@ int main(int argc, const char *argv[]) {
                     "mma_xf32_16_16_8", gops * (16 * 16 * 8 * 2), gbytes);
     }
 #else
-    if (!benchmark.isVolta() && !benchmark.isTuring()) {
-      benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_xor), grid,
-                    block, "bmma_b1_16_8_256_xor", gops * (16 * 8 * 256 * 2),
-                    gbytes);
-      benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_and), grid,
-                    block, "bmma_b1_16_8_256_and", gops * (16 * 8 * 256 * 2),
-                    gbytes);
+    if (!benchmark.isVolta()) {
+      if (!benchmark.isTuring()) {
+        benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_and), grid,
+                      block, "bmma_b1_16_8_256_and", gops * (16 * 8 * 256 * 2),
+                      gbytes);
+        benchmark.run(reinterpret_cast<void *>(&bmma_b1_16_8_256_xor), grid,
+                      block, "bmma_b1_16_8_256_xor", gops * (16 * 8 * 256 * 2),
+                      gbytes);
+        benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_and), grid,
+                      block, "bmma_b1_8_8_128_and", gops * (8 * 8 * 128 * 2),
+                      gbytes);
+      }
       benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_xor), grid, block,
                     "bmma_b1_8_8_128_xor", gops * (8 * 8 * 128 * 2), gbytes);
-      benchmark.run(reinterpret_cast<void *>(&bmma_b1_8_8_128_and), grid, block,
-                    "bmma_b1_8_8_128_and", gops * (8 * 8 * 128 * 2), gbytes);
     }
     if (!benchmark.isVolta()) {
       benchmark.run(reinterpret_cast<void *>(&mma_s4_8_8_32), grid, block,

--- a/common/Benchmark.cpp
+++ b/common/Benchmark.cpp
@@ -112,7 +112,8 @@ Benchmark::Benchmark(int argc, const char *argv[]) {
 
   // Print CUDA device information
   std::cout << "Device " << device_number << ": " << device_->getName();
-  std::cout << " (" << multiProcessorCount();
+  std::cout << " (" << device_->getArch() << ", " << multiProcessorCount()
+            << " ";
 #if defined(__HIP_PLATFORM_AMD__)
   if (isCDNA()) {
     std::cout << "CUs, ";

--- a/kernels/mma.cu
+++ b/kernels/mma.cu
@@ -155,7 +155,7 @@ __device__ void mma_kernel(Tout *data) {
 #include "mma_m8n8k32_s32s4s4s32.cuh"
 #endif
 
-#if __CUDA_ARCH >= 800
+#if __CUDA_ARCH__ >= 800
 #define ENABLE_TF32
 #define ENABLE_BF16
 #endif

--- a/kernels/mma.cu
+++ b/kernels/mma.cu
@@ -144,8 +144,12 @@ __device__ void mma_kernel(Tout *data) {
   END
 }
 
-#if __CUDA_ARCH__ >= 800
+// Turing only supports int1, xor, m8n8k128
+#if __CUDA_ARCH__ >= 750
 #define ENABLE_INT1
+#endif
+
+#if __CUDA_ARCH__ >= 800
 #include "mma_m16n8k256_s32b1b1s32.cuh"
 #endif
 
@@ -190,21 +194,21 @@ __global__ void bmma_b1_8_8_128_xor(void *data) {
 }
 
 __global__ void bmma_b1_16_8_256_xor(void *data) {
-#if defined(ENABLE_INT1)
+#if defined(ENABLE_INT1) && (__CUDA_ARCH__ >= 800)
   bmma_kernel<experimental::precision::b1, int, 16, 8, 256,
               experimental::bmmaBitOpXOR>((int *)data);
 #endif
 }
 
 __global__ void bmma_b1_8_8_128_and(void *data) {
-#if defined(ENABLE_INT1)
+#if defined(ENABLE_INT1) && (__CUDA_ARCH__ >= 800)
   bmma_kernel<experimental::precision::b1, int, 8, 8, 128,
               experimental::bmmaBitOpAND>((int *)data);
 #endif
 }
 
 __global__ void bmma_b1_16_8_256_and(void *data) {
-#if defined(ENABLE_INT1)
+#if defined(ENABLE_INT1) && (__CUDA_ARCH__ >= 800)
   bmma_kernel<experimental::precision::b1, int, 16, 8, 256,
               experimental::bmmaBitOpAND>((int *)data);
 #endif

--- a/kernels/mma.cu
+++ b/kernels/mma.cu
@@ -27,6 +27,13 @@ using namespace nvcuda::wmma;
 
 #define REPEAT_COUNT 32768
 
+inline __device__ unsigned laneid() {
+  unsigned laneid;
+
+  asm("mov.u32 %0, %%laneid;" : "=r"(laneid));
+  return laneid;
+}
+
 #if defined(__HIP_PLATFORM_AMD__)
 
 #if defined(ROCWMMA_VERSION_MAJOR)

--- a/kernels/mma.cu
+++ b/kernels/mma.cu
@@ -153,7 +153,7 @@ __device__ void mma_kernel(Tout *data) {
 #define ENABLE_BF16
 #endif
 
-#if __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 120
+#if __CUDA_ARCH__ == 890 || __CUDA_ARCH__ == 900 || __CUDA_ARCH__ == 1200
 #define ENABLE_FP8
 #include "mma_m16n8k32_f32f8f8f32.cuh"
 #endif

--- a/kernels/mma.cu
+++ b/kernels/mma.cu
@@ -144,7 +144,7 @@ __device__ void mma_kernel(Tout *data) {
   END
 }
 
-#if defined(__CUDA_SUBBYTE_IMMA__)
+#if __CUDA_ARCH__ >= 800
 #define ENABLE_INT1
 #include "mma_m16n8k256_s32b1b1s32.cuh"
 #endif

--- a/kernels/mma_m16n8k256_s32b1b1s32.cuh
+++ b/kernels/mma_m16n8k256_s32b1b1s32.cuh
@@ -2,13 +2,6 @@
 
 using namespace nvcuda::wmma;
 
-inline __device__ unsigned laneid() {
-  unsigned laneid;
-
-  asm("mov.u32 %0, %%laneid;" : "=r"(laneid));
-  return laneid;
-}
-
 template <>
 class fragment<matrix_a, 16, 8, 256, experimental::precision::b1, row_major>
     : public __frag_base<experimental::precision::b1, 32, 4> {};

--- a/kernels/mma_m16n8k32_f32f8f8f32.cuh
+++ b/kernels/mma_m16n8k32_f32f8f8f32.cuh
@@ -1,9 +1,3 @@
-inline __device__ unsigned laneid() {
-  unsigned laneid;
-
-  asm("mov.u32 %0, %%laneid;" : "=r"(laneid));
-  return laneid;
-}
 
 template <>
 class fragment<matrix_a, 16, 8, 32, __nv_fp8_e4m3, row_major>


### PR DESCRIPTION
A number of small issues in the mma code caused the benchmark to misbehave for certain configurations. This is now fixed and along the way, compatibility with the Turing architecture is improved.