### PR TITLE
Add fp4 kernel to mma benchmark

### DIFF
--- a/benchmarks/mma.cpp
+++ b/benchmarks/mma.cpp
@@ -22,8 +22,11 @@ int getBitSize(const std::string &kernel_name) {
   const std::string type = split(kernel_name, '_')[1];
 
   // Handle special cases first
-  if (type == "e4m3" || type == "e5m2")
+  if (type == "e4m3" || type == "e5m2") {
     return 8;
+  } else if (type == "e2m1") {
+    return 4;
+  }
 
   // Default case: try to extract number from type (e.g., "16" from "f16")
   for (char c : type) {
@@ -98,6 +101,10 @@ std::vector<std::string> getSupportedKernels(Benchmark &benchmark) {
   if (benchmark.isAda() || benchmark.isHopper() || benchmark.isBlackwell()) {
     kernel_names.push_back("mma_e4m3_16_8_32");
     kernel_names.push_back("mma_e5m2_16_8_32");
+
+    if (!benchmark.isAda()) {
+      kernel_names.push_back("mma_e2m1_16_8_64");
+    }
   }
 #endif
 

--- a/common/KernelFactory.cpp
+++ b/common/KernelFactory.cpp
@@ -17,7 +17,11 @@ std::vector<std::shared_ptr<cu::Function>>
 KernelFactory::compileKernels(cu::Device &device,
                               const std::vector<std::string> &kernel_names) {
   const std::string cuda_include_path = nvrtc::findIncludePath();
-  const std::string arch = device.getArch();
+  std::string arch = device.getArch();
+
+  if (arch.compare("sm_120") == 0) {
+    arch += "a";
+  }
 
   std::vector<std::string> options = {
       "-I" + cuda_include_path,

--- a/kernels/mma.cu
+++ b/kernels/mma.cu
@@ -16,6 +16,7 @@ struct hip_fp8_e5m2;
 #endif
 
 #else
+#include <cuda_fp4.h>
 #include <cuda_fp8.h>
 #include <mma.h>
 
@@ -136,6 +137,11 @@ __device__ void mma_kernel(Tout *data) {
 #include "mma_m8n8k32_s32s4s4s32.cuh"
 #endif
 
+#if __CUDA_ARCH__ >= 1000
+#define ENABLE_FP4
+#include "mma_m16n8k64_f32f4f4f32.cuh"
+#endif
+
 #if __CUDA_ARCH__ >= 800
 #define ENABLE_TF32
 #define ENABLE_BF16
@@ -228,6 +234,12 @@ __global__ void mma_e4m3_16_8_32(void *data) {
 __global__ void mma_e5m2_16_8_32(void *data) {
 #if defined(ENABLE_FP8)
   mma_kernel_ptx<__nv_fp8_e5m2, float, 16, 8, 32>((float *)data);
+#endif
+}
+
+__global__ void mma_e2m1_16_8_64(void *data) {
+#if defined(ENABLE_FP4)
+  mma_kernel_ptx<__nv_fp4_e2m1, float, 16, 8, 64>((float *)data);
 #endif
 }
 

--- a/kernels/mma_m16n8k32_f32f8f8f32.cuh
+++ b/kernels/mma_m16n8k32_f32f8f8f32.cuh
@@ -1,4 +1,3 @@
-
 template <>
 class fragment<matrix_a, 16, 8, 32, __nv_fp8_e4m3, row_major>
     : public __frag_base<int, 4> {};

--- a/kernels/mma_m16n8k64_f32f4f4f32.cuh
+++ b/kernels/mma_m16n8k64_f32f4f4f32.cuh
@@ -1,0 +1,54 @@
+#include <mma.h>
+
+typedef unsigned int uint32_t;
+typedef unsigned short uint16_t;
+
+using namespace nvcuda::wmma;
+
+template <>
+class fragment<matrix_a, 16, 8, 64, __nv_fp4_e2m1, row_major>
+    : public __frag_base<int, 4> {};
+template <>
+class fragment<matrix_b, 16, 8, 64, __nv_fp4_e2m1, col_major>
+    : public __frag_base<int, 2> {};
+
+template <>
+class fragment<accumulator, 16, 8, 64, float> : public __frag_base<float, 4> {};
+
+inline __device__ void
+mma_sync_ptx(fragment<accumulator, 16, 8, 64, float> &d,
+             const fragment<matrix_a, 16, 8, 64, __nv_fp4_e2m1, row_major> &a,
+             const fragment<matrix_b, 16, 8, 64, __nv_fp4_e2m1, col_major> &b,
+             const fragment<accumulator, 16, 8, 64, float> &c) {
+  static constexpr uint32_t sfa0 = 0x7F7F;
+  static constexpr uint16_t tidA = 0;
+  static constexpr uint16_t bidA = 0;
+  static constexpr uint32_t sfb0 = 0x7F7F;
+  static constexpr uint16_t tidB = 0;
+  static constexpr uint16_t bidB = 0;
+
+  asm("mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::2X.m16n8k64.row."
+      "col.f32.e2m1.e2m1.f32.ue8m0 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, "
+      "%9}, {%10, %11, %12, %13}, {%14}, {%15, %16}, {%17}, {%18, %19};"
+      : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3])
+      : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), "r"(b.x[0]),
+        "r"(b.x[1]), "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]),
+        "r"(uint32_t(sfa0)), "h"(bidA), "h"(tidA), "r"(uint32_t(sfb0)),
+        "h"(bidB), "h"(tidB));
+}
+
+inline __device__ void
+store_matrix_sync(float *p, const fragment<accumulator, 16, 8, 64, float> &d,
+                  unsigned ldm, layout_t layout) {
+  if (layout == mem_row_major) {
+    ((float2 *)p)[ldm / 2 * (laneid() / 4) + laneid() % 4] =
+        make_float2(d.x[0], d.x[1]);
+    ((float2 *)p)[ldm / 2 * (laneid() / 4 + 8) + laneid() % 4] =
+        make_float2(d.x[2], d.x[3]);
+  } else {
+    p[(laneid() % 4) * 2 * ldm + (laneid() / 4)] = d.x[0];
+    p[(laneid() % 4) * 2 * ldm + (laneid() / 4) + ldm] = d.x[1];
+    p[(laneid() % 4) * 2 * ldm + (laneid() / 4 + 8)] = d.x[2];
+    p[(laneid() % 4) * 2 * ldm + (laneid() / 4 + 8) + ldm] = d.x[3];
+  }
+}


### PR DESCRIPTION
Add `fp4` kernel (`mxf4nvf4` kind) to `mma` benchmark.