### PR TITLE
Add alternative int8 kernel

### DIFF
--- a/benchmarks/mma.cpp
+++ b/benchmarks/mma.cpp
@@ -87,6 +87,7 @@ std::vector<std::string> getSupportedKernels(Benchmark &benchmark) {
   if (!benchmark.isVolta()) {
     kernel_names.push_back("mma_s4_8_8_32");
     kernel_names.push_back("mma_s8_16_16_16");
+    kernel_names.push_back("mma_s8_16_8_32");
 
     kernel_names.push_back("bmma_b1_8_8_128_xor");
     if (!benchmark.isTuring()) {

--- a/kernels/mma_m16n8k32_f32f6f6f32.cuh
+++ b/kernels/mma_m16n8k32_f32f6f6f32.cuh
@@ -18,7 +18,8 @@ mma_sync_ptx(fragment<accumulator, 16, 8, 32, float> &d,
              const fragment<matrix_b, 16, 8, 32, __nv_fp6_e2m3, col_major> &b,
              const fragment<accumulator, 16, 8, 32, float> &c) {
 
-  asm("mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f32.e3m2.e2m3.f32 {%0, %1, %2, %3}, "
+  asm("mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f32.e3m2.e2m3.f32 {%0, "
+      "%1, %2, %3}, "
       "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};"
       : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3])
       : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), "r"(b.x[0]),

--- a/kernels/mma_m16n8k32_f32f6f6f32.cuh
+++ b/kernels/mma_m16n8k32_f32f6f6f32.cuh
@@ -1,8 +1,5 @@
 #include <cuda_fp6.h>
 
-typedef unsigned int uint32_t;
-typedef unsigned short uint16_t;
-
 using namespace nvcuda::wmma;
 
 template <>

--- a/kernels/mma_m16n8k32_f32f6f6f32.cuh
+++ b/kernels/mma_m16n8k32_f32f6f6f32.cuh
@@ -1,0 +1,26 @@
+#include <cuda_fp6.h>
+
+typedef unsigned int uint32_t;
+typedef unsigned short uint16_t;
+
+using namespace nvcuda::wmma;
+
+template <>
+class fragment<matrix_a, 16, 8, 32, __nv_fp6_e3m2, row_major>
+    : public __frag_base<int, 4> {};
+template <>
+class fragment<matrix_b, 16, 8, 32, __nv_fp6_e2m3, col_major>
+    : public __frag_base<int, 2> {};
+
+inline __device__ void
+mma_sync_ptx(fragment<accumulator, 16, 8, 32, float> &d,
+             const fragment<matrix_a, 16, 8, 32, __nv_fp6_e3m2, row_major> &a,
+             const fragment<matrix_b, 16, 8, 32, __nv_fp6_e2m3, col_major> &b,
+             const fragment<accumulator, 16, 8, 32, float> &c) {
+
+  asm("mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f32.e3m2.e2m3.f32 {%0, %1, %2, %3}, "
+      "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};"
+      : "=f"(d.x[0]), "=f"(d.x[1]), "=f"(d.x[2]), "=f"(d.x[3])
+      : "r"(a.x[0]), "r"(a.x[1]), "r"(a.x[2]), "r"(a.x[3]), "r"(b.x[0]),
+        "r"(b.x[1]), "f"(c.x[0]), "f"(c.x[1]), "f"(c.x[2]), "f"(c.x[3]));
+}

--- a/kernels/mma_nvidia.cuh
+++ b/kernels/mma_nvidia.cuh
@@ -37,6 +37,7 @@ __device__ void mma_kernel(Tout *data) {
 #define ENABLE_INT4
 #define ENABLE_INT8
 #include "mma_m8n8k32_s32s4s4s32.cuh"
+#include "mma_m8n8k32_s32s8s8s32.cuh"
 #endif
 
 template <>
@@ -119,6 +120,12 @@ __global__ void mma_s4_8_8_32(void *data) {
 __global__ void mma_s8_16_16_16(void *data) {
 #if defined(ENABLE_INT8)
   mma_kernel<signed char, signed char, int, 16, 16, 16>((int *)data);
+#endif
+}
+
+__global__ void mma_s8_16_8_32(void *data) {
+#if defined(ENABLE_INT8)
+  mma_kernel_ptx<signed char, signed char, int, 16, 8, 32>((int *)data);
 #endif
 }
 


### PR DESCRIPTION
The `mma` benchmark already runs a `mma_s8_16_16_16` kernel, a new `mma_s8_16_8_32` is added.

In https://github.com/astron-rd/cudapeak/pull/10, `kernels/mma_m16n8k32_f32f6f6f32.cuh` was not added. This is now fixed as well.